### PR TITLE
Stats, tweaks and query parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "src/index.js",
   "license": "MPL-2.0",
   "scripts": {
-    "dev": "webpack-dev-server --open --config webpack.dev.js",
+    "dev": "webpack-dev-server --https --open --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
     "prettier": "prettier --write src/**/*.js",
     "deploy": "npm run build && now deploy --static ./public/"

--- a/public/index.html
+++ b/public/index.html
@@ -55,7 +55,7 @@
         </a-assets>
 
         <a-entity id="player-rig" networked wasd-controls snap-rotation="pivotSrc: #head">
-            <a-sphere scale="0.1 0.1 0.1"></a-sphere>
+            <a-sphere scale="0.1 0.1 0.1" segments-height="6" segments-width="8"></a-sphere>
             <a-entity id="head" camera="userHeight: 1.6" personal-space-bubble look-controls networked="template:#head-template;showLocalTemplate:false;"></a-entity>
 
             <a-entity id="nametag" networked="template:#nametag-template;showLocalTemplate:false;"></a-entity>

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,10 @@ window.onSceneLoad = function() {
     scene.setAttribute("networked-scene", "room", parseInt(qs.room));
   }
 
+  if (!qs.stats || !/off|false|0/.test(qs.stats)) {
+    scene.setAttribute('stats', true);
+  }
+
   const username = promptForName(); // promptForName is blocking
   const myNametag = document.querySelector("#player-rig .nametag");
   myNametag.setAttribute("text", "value", username);

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,10 @@ window.onSceneLoad = function() {
     scene.setAttribute('stats', true);
   }
 
-  const username = promptForName(); // promptForName is blocking
+  let username = qs.name;
+  if (!username) {
+    username = promptForName(username); // promptForName is blocking
+  }
   const myNametag = document.querySelector("#player-rig .nametag");
   myNametag.setAttribute("text", "value", username);
 


### PR DESCRIPTION
- Use `https://` for local host so that Firefox can remember your permissions.
- Turn `stats` on by default unless `?stats=off` (or falsy).
- Skip generating and prompting for a username if `?name=` is specified.
- Reduce geometry of sphere.
