### PR TITLE
Fix glTF Caching in gltf-model2 component

### DIFF
--- a/public/room.html
+++ b/public/room.html
@@ -53,7 +53,7 @@
                     networked-audio-source
                     networked-audio-analyser
                     matcolor-audio-feedback="objectName: Head_Mesh"
-                    gltf-model2="#bot-head-mesh"
+                    cached-gltf-model="#bot-head-mesh"
                     scale-audio-feedback
                     personal-space-invader
                     rotation="0 180 0"
@@ -64,7 +64,7 @@
             <script id="body-template" type="text/html">
                 <a-entity
                     class="body"
-                    gltf-model2="#bot-body-mesh"
+                    cached-gltf-model="#bot-body-mesh"
                     personal-space-invader
                     rotation="0 180 0"
                     position="0 -0.05 0"
@@ -74,7 +74,7 @@
             <script id="left-hand-template" type="text/html">
                 <a-entity
                     class="hand"
-                    gltf-model2="#bot-left-hand-mesh"
+                    cached-gltf-model="#bot-left-hand-mesh"
                     animation-mixer
                     personal-space-invader
                     rotation="-90 90 0"
@@ -85,7 +85,7 @@
             <script id="right-hand-template" type="text/html">
                 <a-entity
                     class="hand"
-                    gltf-model2="#bot-right-hand-mesh"
+                    cached-gltf-model="#bot-right-hand-mesh"
                     personal-space-invader
                     rotation="-90 -90 0"
                     position="0 0 0.075"
@@ -144,7 +144,7 @@
             >
                 <a-entity
                     id="watch"
-                    gltf-model2="assets/hud/watch.gltf"
+                    cached-gltf-model="assets/hud/watch.gltf"
                     position="0 0.0015 0.147"
                     rotation="3.5 0 0"
                 >
@@ -175,17 +175,17 @@
 
         <!-- Environment -->
         <a-entity
-            gltf-model2="#meeting-space1-mesh"
+            cached-gltf-model="#meeting-space1-mesh"
             position="0 0 0"
         ></a-entity>
 
         <a-entity
-            gltf-model2="#outdoor-facade-mesh"
+            cached-gltf-model="#outdoor-facade-mesh"
             position="0 0 0"
         ></a-entity>
 
         <a-entity
-            gltf-model2="#floor-nav-mesh"
+            cached-gltf-model="#floor-nav-mesh"
             visible="false"
             position="0 0 0"
         ></a-entity>

--- a/public/room.html
+++ b/public/room.html
@@ -50,10 +50,10 @@
             <script id="head-template" type="text/html">
                 <a-entity
                     class="head"
-                    gltf-model2="#bot-head-mesh"
                     networked-audio-source
                     networked-audio-analyser
                     matcolor-audio-feedback="objectName: Head_Mesh"
+                    gltf-model2="#bot-head-mesh"
                     scale-audio-feedback
                     personal-space-invader
                     rotation="0 180 0"

--- a/src/components/cached-gltf-model.js
+++ b/src/components/cached-gltf-model.js
@@ -4,7 +4,7 @@ const GLTFCache = {};
 
 // From https://gist.github.com/cdata/f2d7a6ccdec071839bc1954c32595e87
 // Tracking glTF cloning here: https://github.com/mrdoob/three.js/issues/11573
-const cloneGltf = gltf => {
+function cloneGltf(gltf) {
   const clone = {
     animations: gltf.animations,
     scene: gltf.scene.clone(true)
@@ -52,12 +52,12 @@ const cloneGltf = gltf => {
   }
 
   return clone;
-};
+}
 
 /**
  * glTF model loader.
  */
-AFRAME.registerComponent("gltf-model2", {
+AFRAME.registerComponent("cached-gltf-model", {
   schema: { type: "model" },
 
   init: function() {

--- a/src/components/gltf-model2.js
+++ b/src/components/gltf-model2.js
@@ -47,6 +47,8 @@ const cloneGltf = gltf => {
       new THREE.Skeleton(orderedCloneBones, skeleton.boneInverses),
       cloneSkinnedMesh.matrixWorld
     );
+
+    cloneSkinnedMesh.material = skinnedMesh.material.clone();
   }
 
   return clone;

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ import "./components/character-controller";
 import "./components/split-axis-events";
 import "./components/networked-video-player";
 import "./components/offset-relative-to";
-import "./components/gltf-model2";
+import "./components/cached-gltf-model";
 import "./systems/personal-space-bubble";
 
 import registerNetworkScheams from "./network-schemas";


### PR DESCRIPTION
Cloning a glTF model is more complicated than just calling `.clone()` on the model returned from the loader. There is an issue tracking this in the Three.js repo: https://github.com/mrdoob/three.js/issues/11573. In the meantime I've added a workaround.

Also `matcolor-audio-feedback` needs to set the color property on the head object's material. So I added material cloning to the clone method. The component also needs to be loaded before the `gltf-model2` component so that it receives the `model-loaded` event which is now emitted immediately when the model is cached.