### PR TITLE
Add sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "networked-aframe": "https://github.com/netpro2k/networked-aframe#bugfix/chrome/audio",
     "nipplejs": "^0.6.7",
     "query-string": "^5.0.1",
+    "raven-js": "^3.20.1",
     "react": "^16.1.1",
     "react-dom": "^16.1.1",
     "webrtc-adapter": "^6.0.2"

--- a/src/lobby.js
+++ b/src/lobby.js
@@ -6,6 +6,10 @@ import "material-design-lite";
 import "material-design-lite/material.css";
 import "./lobby.css";
 
+import registerTelemetry from "./telemetry";
+
+registerTelemetry();
+
 class Lobby extends React.Component {
   constructor() {
     super();

--- a/src/room.js
+++ b/src/room.js
@@ -38,6 +38,7 @@ import "./systems/personal-space-bubble";
 import { promptForName, getCookie, parseJwt } from "./utils";
 import registerNetworkSchemas from "./network-schemas";
 import { inGameActions, config } from "./input-mappings";
+import registerTelemetry from "./telemetry";
 
 AFRAME.registerInputBehaviour("vive_trackpad_dpad4", vive_trackpad_dpad4);
 AFRAME.registerInputBehaviour(
@@ -50,6 +51,7 @@ AFRAME.registerInputActions(inGameActions, "default");
 AFRAME.registerInputMappings(config);
 
 registerNetworkSchemas();
+registerTelemetry();
 
 function shareScreen() {
   const track = NAF.connection.adapter.localMediaStream.getVideoTracks()[0];

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -1,0 +1,7 @@
+import Raven from "raven-js";
+
+export default function registerTelemetry() {
+  Raven.config(
+    "https://f571beaf5cee4e3085e0bf436f3eb158@sentry.io/256771"
+  ).install();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4738,6 +4738,10 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
+raven-js@^3.20.1:
+  version "3.20.1"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.20.1.tgz#3170bdb35c05098ddb8548ee5be0687f9d763330"
+
 raw-body@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"


### PR DESCRIPTION
This PR adds sentry error reporting to the app. Note: we will need to revisit this before going live (likely by standing up a sentry cluster on AWS) since we do not want to be sending user-generated data to a 3rd party.