### PR TITLE
Don't block connection on microphone, screen sharing permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "aframe-teleport-controls": "https://github.com/netpro2k/aframe-teleport-controls#feature/teleport-origin",
     "extract-text-webpack-plugin": "^3.0.2",
     "material-design-lite": "^1.3.0",
-    "minijanus": "^0.1.6",
+    "minijanus": "^0.4.0",
     "naf-janus-adapter": "^0.1.10",
     "networked-aframe": "https://github.com/netpro2k/networked-aframe#bugfix/chrome/audio",
     "nipplejs": "^0.6.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "extract-text-webpack-plugin": "^3.0.2",
     "material-design-lite": "^1.3.0",
     "minijanus": "^0.4.0",
-    "naf-janus-adapter": "^0.1.10",
+    "naf-janus-adapter": "^0.3.0",
     "networked-aframe": "https://github.com/netpro2k/networked-aframe#bugfix/chrome/audio",
     "nipplejs": "^0.6.7",
     "query-string": "^5.0.1",

--- a/src/lobby.js
+++ b/src/lobby.js
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import mj from "minijanus";
+import { JanusSession, JanusPluginHandle } from "minijanus";
 
 import "material-design-lite";
 import "material-design-lite/material.css";
@@ -22,7 +22,7 @@ class Lobby extends React.Component {
 
   componentDidMount() {
     this.ws = new WebSocket(window.CONFIG.janus_server_url, "janus-protocol");
-    this.session = new mj.JanusSession(this.ws.send.bind(this.ws));
+    this.session = new JanusSession(this.ws.send.bind(this.ws));
     this.ws.addEventListener("open", this.onWebsocketOpen);
     this.ws.addEventListener("message", this.onWebsocketMessage);
   }
@@ -37,7 +37,7 @@ class Lobby extends React.Component {
     this.session
       .create()
       .then(() => {
-        this.handle = new mj.JanusPluginHandle(this.session);
+        this.handle = new JanusPluginHandle(this.session);
         return this.handle.attach("janus.plugin.sfu").then(this.updateRooms);
       })
       .then(() => {

--- a/src/lobby.js
+++ b/src/lobby.js
@@ -5,6 +5,7 @@ import { JanusSession, JanusPluginHandle } from "minijanus";
 import "material-design-lite";
 import "material-design-lite/material.css";
 import "./lobby.css";
+import "webrtc-adapter";
 
 import registerTelemetry from "./telemetry";
 

--- a/src/lobby.js
+++ b/src/lobby.js
@@ -62,8 +62,7 @@ class Lobby extends React.Component {
   }
 
   onWebsocketMessage(event) {
-    var message = JSON.parse(event.data);
-    this.session.receive(message);
+    this.session.receive(JSON.parse(event.data));
   }
 
   render() {

--- a/src/room.js
+++ b/src/room.js
@@ -58,12 +58,19 @@ AFRAME.registerInputMappings(config);
 registerNetworkSchemas();
 registerTelemetry();
 
-function shareScreen() {
-  const track = NAF.connection.adapter.localMediaStream.getVideoTracks()[0];
+async function shareMedia(audio, video) {
+  const constraints = {
+    audio: !!audio,
+    video: video ? { mediaSource: "screen", height: 720, frameRate: 30 } : false
+  };
+  const mediaStream = await navigator.mediaDevices.getUserMedia(constraints);
+  NAF.connection.adapter.setLocalMediaStream(mediaStream);
 
   const id = `${NAF.clientId}-screen`;
   let entity = document.getElementById(id);
-  if (!entity) {
+  if (entity) {
+    entity.setAttribute("visible", !!video);
+  } else if (video) {
     const sceneEl = document.querySelector("a-scene");
     entity = document.createElement("a-entity");
     entity.id = id;
@@ -75,12 +82,10 @@ function shareScreen() {
     entity.setAttribute("networked", { template: "#video-template" });
     sceneEl.appendChild(entity);
   }
-
-  track.enabled = !track.enabled;
-  entity.setAttribute("visible", track.enabled);
 }
 
 window.App = {
+
   async onSceneLoad() {
     const qs = queryString.parse(location.search);
     const scene = document.querySelector("a-scene");
@@ -119,31 +124,20 @@ window.App = {
     const myNametag = document.querySelector("#player-rig .nametag");
     myNametag.setAttribute("text", "value", username);
 
-    scene.addEventListener("action_share_screen", shareScreen);
-
-    const mediaStream = await navigator.mediaDevices.getUserMedia({
-      audio: true,
-      video:
-        qs.screen === "true"
-          ? { mediaSource: "screen", height: 720, frameRate: 30 }
-          : false
+    var sharingScreen = false;
+    scene.addEventListener("action_share_screen", () => {
+      sharingScreen = !sharingScreen;
+      shareMedia(true, sharingScreen);
     });
-
-    // Don't send video by deafult
-    const videoTracks = mediaStream.getVideoTracks();
-    if (videoTracks.length) {
-      videoTracks[0].enabled = false;
-    }
 
     if (qs.offline) {
       App.onConnect();
     } else {
+      document.body.addEventListener("connected", App.onConnect);
+
       scene.components["networked-scene"].connect();
 
-      // @TODO ideally the adapter should exist before connect, but it currently doesnt so we have to do this after calling connect. This might be a race condition in other adapters.
-      NAF.connection.adapter.setLocalMediaStream(mediaStream);
-
-      document.body.addEventListener("connected", App.onConnect);
+      await shareMedia(true, sharingScreen);
     }
   },
 

--- a/src/room.js
+++ b/src/room.js
@@ -9,6 +9,7 @@ import "networked-aframe";
 import "naf-janus-adapter";
 import "aframe-teleport-controls";
 import "aframe-input-mapping-component";
+import "webrtc-adapter";
 
 import animationMixer from "aframe-extras/src/loaders/animation-mixer";
 AFRAME.registerComponent("animation-mixer", animationMixer);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3690,6 +3690,10 @@ minijanus@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/minijanus/-/minijanus-0.1.7.tgz#a4aba659e0fc46127450aa440b32de82c6cc46b9"
 
+minijanus@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/minijanus/-/minijanus-0.4.0.tgz#4d08529da795886b1aab6714ee7c9ff122c8c802"
+
 minimalistic-assert@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz#702be2dda6b37f4836bcb3f5db56641b64a1d3d3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3686,10 +3686,6 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
-minijanus@^0.1.6:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/minijanus/-/minijanus-0.1.7.tgz#a4aba659e0fc46127450aa440b32de82c6cc46b9"
-
 minijanus@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/minijanus/-/minijanus-0.4.0.tgz#4d08529da795886b1aab6714ee7c9ff122c8c802"
@@ -3794,12 +3790,12 @@ mv@^2.1.1:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-naf-janus-adapter@^0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/naf-janus-adapter/-/naf-janus-adapter-0.1.10.tgz#322d5eeccefc5078da7e4355537d739bbb167794"
+naf-janus-adapter@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/naf-janus-adapter/-/naf-janus-adapter-0.3.0.tgz#fee55fe0f4724238da5f87fbb0e7f75cd522905e"
   dependencies:
     debug "^3.1.0"
-    minijanus "^0.1.6"
+    minijanus "^0.4.0"
 
 nan@^2.3.0:
   version "2.8.0"


### PR DESCRIPTION
This takes advantage of new renegotiation support in naf-janus-adapter and in Janus to accomplish this. Basically, now we can call `setLocalMediaStream` at any time, so we just connect without any regard to whether we have a local media stream yet and then set the media stream if and when we obtain it.

(We still prompt for microphone permissions at startup, since we think more or less everyone wants to use their microphone. But we don't wait to connect until they're granted, and we don't prompt for screen sharing permissions until a user presses `v`.)