### PR TITLE
Bug/infinite loop in template hydration

### DIFF
--- a/src/elements/a-gltf-entity.js
+++ b/src/elements/a-gltf-entity.js
@@ -93,17 +93,16 @@ function attachTemplate(templateEl) {
   const targetEls = templateEl.parentNode.querySelectorAll(selector);
   const clone = document.importNode(templateEl.content, true);
   const templateRoot = clone.firstElementChild;
-  const templateRootAttrs = templateRoot.attributes;
 
-  for (const targetEl of targetEls) {
+  for (const el of targetEls) {
     // Merge root element attributes with the target element
-    for (const { name, value } of templateRootAttrs) {
-      targetEl.setAttribute(name, value);
+    for (const { name, value } of templateRoot.attributes) {
+      el.setAttribute(name, value);
     }
 
     // Append all child elements
     for (const child of templateRoot.children) {
-      targetEl.appendChild(document.importNode(child, true));
+      el.appendChild(document.importNode(child, true));
     }
   }
 }

--- a/src/elements/a-gltf-entity.js
+++ b/src/elements/a-gltf-entity.js
@@ -95,17 +95,17 @@ function attachTemplate(templateEl) {
   const templateRoot = clone.firstElementChild;
   const templateRootAttrs = templateRoot.attributes;
 
-  for (var i = 0; i < targetEls.length; i++) {
+  for (let i = 0; i < targetEls.length; i++) {
     const targetEl = targetEls[i];
 
     // Merge root element attributes with the target element
-    for (var i = 0; i < templateRootAttrs.length; i++) {
-      targetEl.setAttribute(templateRootAttrs[i].name, templateRootAttrs[i].value);
+    for (let j = 0; j < templateRootAttrs.length; j++) {
+      targetEl.setAttribute(templateRootAttrs[j].name, templateRootAttrs[j].value);
     }
 
     // Append all child elements
-    for (var i = 0; i < templateRoot.children.length; i++) {
-      targetEl.appendChild(document.importNode(templateRoot.children[i], true));
+    for (let j = 0; j < templateRoot.children.length; j++) {
+      targetEl.appendChild(document.importNode(templateRoot.children[j], true));
     }
   }
 }

--- a/src/elements/a-gltf-entity.js
+++ b/src/elements/a-gltf-entity.js
@@ -95,17 +95,15 @@ function attachTemplate(templateEl) {
   const templateRoot = clone.firstElementChild;
   const templateRootAttrs = templateRoot.attributes;
 
-  for (let i = 0; i < targetEls.length; i++) {
-    const targetEl = targetEls[i];
-
+  for (const targetEl of targetEls) {
     // Merge root element attributes with the target element
-    for (let j = 0; j < templateRootAttrs.length; j++) {
-      targetEl.setAttribute(templateRootAttrs[j].name, templateRootAttrs[j].value);
+    for (const { name, value } of templateRootAttrs) {
+      targetEl.setAttribute(name, value);
     }
 
     // Append all child elements
-    for (let j = 0; j < templateRoot.children.length; j++) {
-      targetEl.appendChild(document.importNode(templateRoot.children[j], true));
+    for (const child of templateRoot.children) {
+      targetEl.appendChild(document.importNode(child, true));
     }
   }
 }


### PR DESCRIPTION
Fix issue with infinite loop due to loop binding on `i` being reused.