### PR TITLE
Space Bubble fixes and improvments

### DIFF
--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -77,6 +77,7 @@ AFRAME.registerComponent("scale-audio-feedback", {
   },
 
   onAudioFrequencyChange(e) {
+    if (!this.el.object3D.visible) return;
     const { minScale, maxScale } = this.data;
     this.el.object3D.scale.setScalar(minScale + (maxScale - minScale) * e.detail.volume / 255);
   }

--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -77,6 +77,8 @@ AFRAME.registerComponent("scale-audio-feedback", {
   },
 
   onAudioFrequencyChange(e) {
+    // TODO: come up with a cleaner way to handle this.
+    // bone's are "hidden" by scaling them with bone-visibility, without this we would overwrite that.
     if (!this.el.object3D.visible) return;
     const { minScale, maxScale } = this.data;
     this.el.object3D.scale.setScalar(minScale + (maxScale - minScale) * e.detail.volume / 255);

--- a/src/components/bone-visibility.js
+++ b/src/components/bone-visibility.js
@@ -1,0 +1,16 @@
+AFRAME.registerComponent("bone-visibility", {
+  tick() {
+    const { visible } = this.el.object3D;
+
+    if (this.lastVisible !== visible) {
+      if (visible) {
+        this.el.object3D.scale.set(1, 1, 1);
+      } else {
+        // Three.js doesn't like updating matrices with 0 scale, so we set it to a near zero number.
+        this.el.object3D.scale.set(0.00000001, 0.00000001, 0.00000001);
+      }
+
+      this.lastVisible = visible;
+    }
+  }
+});

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -1,5 +1,4 @@
 const { Vector3, Quaternion, Matrix4, Euler } = THREE;
-
 AFRAME.registerComponent("ik-root", {
   schema: {
     camera: { type: "string", default: ".camera" },
@@ -67,16 +66,12 @@ AFRAME.registerComponent("ik-controller", {
 
     this.hands = {
       left: {
-        lastVisible: true,
         rotation: new Matrix4().makeRotationFromEuler(new Euler(-Math.PI / 2, Math.PI / 2, 0))
       },
       right: {
-        lastVisible: true,
         rotation: new Matrix4().makeRotationFromEuler(new Euler(Math.PI / 2, Math.PI / 2, 0))
       }
     };
-
-    this.headLastVisible = true;
   },
 
   update(oldData) {
@@ -180,14 +175,6 @@ AFRAME.registerComponent("ik-controller", {
 
     this.updateHand(this.hands.left, leftHand, leftController);
     this.updateHand(this.hands.right, rightHand, rightController);
-
-    if (head.object3D.visible) {
-      if (!this.headLastVisible) {
-        head.object3D.scale.set(1, 1, 1);
-      }
-    } else if (this.headLastVisible) {
-      head.object3D.scale.set(0.0000001, 0.0000001, 0.0000001);
-    }
   },
 
   updateHand(handState, hand, controller) {
@@ -195,11 +182,8 @@ AFRAME.registerComponent("ik-controller", {
     const handMatrix = handObject3D.matrix;
     const controllerObject3D = controller.object3D;
 
+    handObject3D.visible = controllerObject3D.visible;
     if (controllerObject3D.visible) {
-      if (!handState.lastVisible) {
-        handObject3D.scale.set(1, 1, 1);
-        handState.lastVisible = true;
-      }
       handMatrix.multiplyMatrices(this.invRootToChest, controllerObject3D.matrix);
 
       const handControls = controller.components["hand-controls2"];
@@ -212,11 +196,6 @@ AFRAME.registerComponent("ik-controller", {
 
       handObject3D.position.setFromMatrixPosition(handMatrix);
       handObject3D.rotation.setFromRotationMatrix(handMatrix);
-    } else {
-      if (handState.lastVisible) {
-        handObject3D.scale.set(0.0000001, 0.0000001, 0.0000001);
-        handState.lastVisible = false;
-      }
     }
   }
 });

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -182,7 +182,12 @@ AFRAME.registerComponent("ik-controller", {
     const handMatrix = handObject3D.matrix;
     const controllerObject3D = controller.object3D;
 
-    handObject3D.visible = controllerObject3D.visible;
+    // TODO: This coupling with personal-space-invader is not ideal.
+    // There should be some intermediate thing managing multiple opinions about object visibility
+    const spaceInvader = hand.components["personal-space-invader"];
+    const handHiddenByPersonalSpace = spaceInvader && spaceInvader.invading;
+
+    handObject3D.visible = !handHiddenByPersonalSpace && controllerObject3D.visible;
     if (controllerObject3D.visible) {
       handMatrix.multiplyMatrices(this.invRootToChest, controllerObject3D.matrix);
 

--- a/src/hub.html
+++ b/src/hub.html
@@ -21,7 +21,7 @@
         networked-scene="adapter: janus; audio: true; debug: true; connectOnLoad: false;"
         physics
         mute-mic="eventSrc: a-scene; toggleEvents: action_mute"
-        personal-space-bubble="debug: true;"
+        personal-space-bubble="debug: false;"
 
         app-mode-input-mappings="modes: default, hud; actionSets: default, hud;"
         >

--- a/src/hub.html
+++ b/src/hub.html
@@ -21,6 +21,7 @@
         networked-scene="adapter: janus; audio: true; debug: true; connectOnLoad: false;"
         physics
         mute-mic="eventSrc: a-scene; toggleEvents: action_mute"
+        personal-space-bubble="debug: false;"
 
         app-mode-input-mappings="modes: default, hud; actionSets: default, hud;"
         >
@@ -130,21 +131,26 @@
                              </a-entity>
                         </template>
 
+                        <template data-selector=".Chest">
+                            <a-entity personal-space-invader="radius: 0.2" bone-visibility></a-entity>
+                        </template>
+
                         <template data-selector=".Head">
                             <a-entity
                                 networked-audio-source
                                 networked-audio-analyser
-                                personal-space-invader
+                                personal-space-invader="radius: 0.15"
+                                bone-visibility
                             >
                             </a-entity>
                         </template>
 
                         <template data-selector=".LeftHand">
-                            <a-entity personal-space-invader ></a-entity>
+                            <a-entity personal-space-invader="radius: 0.1" bone-visibility></a-entity>
                         </template>
 
                         <template data-selector=".RightHand">
-                            <a-entity personal-space-invader ></a-entity>
+                            <a-entity personal-space-invader="radius: 0.1" bone-visibility></a-entity>
                         </template>
                     </a-entity>
                 </a-entity>
@@ -233,7 +239,7 @@
                 class="camera"
                 camera
                 position="0 1.6 0"
-                personal-space-bubble
+                personal-space-bubble="radius: 0.4"
                 look-controls
             ></a-entity>
 
@@ -281,11 +287,11 @@
                 </template>
 
                 <template data-selector=".Head">
-                    <a-entity visible="false"></a-entity>
+                    <a-entity visible="false" bone-visibility></a-entity>
                 </template>
 
                 <template data-selector=".LeftHand">
-                    <a-entity>
+                    <a-entity bone-visibility>
                         <a-entity
                             id="watch"
                             gltf-model-plus="src: #watch-model"
@@ -304,7 +310,7 @@
                 </template>
 
                 <template data-selector=".RightHand">
-                    <a-entity>
+                    <a-entity bone-visibility>
                         <a-entity
                             event-repeater="events: action_grab, action_release; eventSource: #player-right-controller"
                             static-body="shape: sphere; sphereRadius: 0.02"

--- a/src/hub.html
+++ b/src/hub.html
@@ -21,7 +21,7 @@
         networked-scene="adapter: janus; audio: true; debug: true; connectOnLoad: false;"
         physics
         mute-mic="eventSrc: a-scene; toggleEvents: action_mute"
-        personal-space-bubble="debug: false;"
+        personal-space-bubble="debug: true;"
 
         app-mode-input-mappings="modes: default, hud; actionSets: default, hud;"
         >
@@ -116,7 +116,7 @@
 
                     <a-entity class="model" gltf-model-plus="inflate: true">
                         <template data-selector=".RootScene">
-                            <a-entity ik-controller animation-mixer></a-entity>
+                            <a-entity ik-controller animation-mixer space-invader-mesh="meshSelector: .Bot_Skinned"></a-entity>
                         </template>
 
                         <template data-selector=".Neck">
@@ -132,14 +132,14 @@
                         </template>
 
                         <template data-selector=".Chest">
-                            <a-entity personal-space-invader="radius: 0.2" bone-visibility></a-entity>
+                            <a-entity personal-space-invader="radius: 0.2; useMaterial: true;" bone-visibility></a-entity>
                         </template>
 
                         <template data-selector=".Head">
                             <a-entity
                                 networked-audio-source
                                 networked-audio-analyser
-                                personal-space-invader="radius: 0.15"
+                                personal-space-invader="radius: 0.15; useMaterial: true;"
                                 bone-visibility
                             >
                             </a-entity>

--- a/src/hub.js
+++ b/src/hub.js
@@ -23,6 +23,7 @@ import "./components/wasd-to-analog2d"; //Might be a behaviour or activator in t
 import "./components/mute-mic";
 import "./components/audio-feedback";
 import "./components/bone-mute-state-indicator";
+import "./components/bone-visibility";
 import "./components/in-world-hud";
 import "./components/virtual-gamepad-controls";
 import "./components/ik-controller";

--- a/src/systems/personal-space-bubble.js
+++ b/src/systems/personal-space-bubble.js
@@ -49,7 +49,7 @@ AFRAME.registerSystem("personal-space-bubble", {
 
     for (let i = 0; i < this.invaders.length; i++) {
       this.invaders[i].el.object3D.updateMatrixWorld(true);
-      this.invaders[i].setVisibility(true);
+      this.invaders[i].setInvading(false);
     }
 
     // Loop through all of the space bubbles (usually one)
@@ -69,7 +69,7 @@ AFRAME.registerSystem("personal-space-bubble", {
         const distanceSquared = bubblePos.distanceToSquared(invaderPos);
         const radius = bubbleRadius + invader.data.radius;
         if (distanceSquared < radius * radius) {
-          invader.setVisibility(false);
+          invader.setInvading(true);
         }
       }
     }
@@ -120,8 +120,8 @@ AFRAME.registerComponent("personal-space-invader", {
       if (mesh) {
         this.targetMaterial = mesh.material;
       }
-      console.log("invader mesh", this.targetMesh);
     }
+    this.invading = false;
   },
 
   update() {
@@ -132,13 +132,14 @@ AFRAME.registerComponent("personal-space-invader", {
     this.el.sceneEl.systems["personal-space-bubble"].unregisterInvader(this);
   },
 
-  setVisibility(visible) {
+  setInvading(invading) {
     if (this.targetMaterial) {
-      this.targetMaterial.opacity = visible ? 1 : 0.3;
-      this.targetMaterial.transparent = !visible;
+      this.targetMaterial.opacity = invading ? 0.3 : 1;
+      this.targetMaterial.transparent = invading;
     } else {
-      this.el.object3D.visible = visible;
+      this.el.object3D.visible = !invading;
     }
+    this.invading = invading;
   }
 });
 

--- a/src/systems/personal-space-bubble.js
+++ b/src/systems/personal-space-bubble.js
@@ -94,7 +94,7 @@ AFRAME.registerComponent("space-invader-mesh", {
   }
 });
 
-function findInvderMesh(entity) {
+function findInvaderMesh(entity) {
   while (entity && !(entity.components && entity.components["space-invader-mesh"])) {
     entity = entity.parentNode;
   }
@@ -114,7 +114,7 @@ AFRAME.registerComponent("personal-space-invader", {
       this.el.object3D.add(createSphereGizmo(this.data.radius));
     }
     if (this.data.useMaterial) {
-      const mesh = findInvderMesh(this.el);
+      const mesh = findInvaderMesh(this.el);
       if (mesh) {
         this.targetMaterial = mesh.material;
       }

--- a/src/systems/personal-space-bubble.js
+++ b/src/systems/personal-space-bubble.js
@@ -100,7 +100,6 @@ AFRAME.registerComponent("space-invader-mesh", {
   },
   init() {
     this.targetMesh = this.el.querySelector(this.data.meshSelector).object3DMap.skinnedmesh;
-    console.log("target", this.targetMesh);
   }
 });
 

--- a/src/systems/personal-space-bubble.js
+++ b/src/systems/personal-space-bubble.js
@@ -41,6 +41,16 @@ AFRAME.registerSystem("personal-space-bubble", {
     }
   },
 
+  update() {
+    for (let i = 0; i < this.bubbles.length; i++) {
+      this.bubbles[i].updateDebug();
+    }
+
+    for (let i = 0; i < this.invaders.length; i++) {
+      this.invaders[i].updateDebug();
+    }
+  },
+
   tick() {
     // Update matrix positions once for each space bubble and space invader
     for (let i = 0; i < this.bubbles.length; i++) {
@@ -101,18 +111,19 @@ function findInvaderMesh(entity) {
   return entity && entity.components["space-invader-mesh"].targetMesh;
 }
 
+const DEBUG_OBJ = "psb-debug";
+
 AFRAME.registerComponent("personal-space-invader", {
   schema: {
     radius: { type: "number", default: 0.1 },
     useMaterial: { default: false },
-    debug: { default: false }
+    debug: { default: false },
+    invadingOpacity: { default: 0.3 }
   },
+
   init() {
     const system = this.el.sceneEl.systems["personal-space-bubble"];
     system.registerInvader(this);
-    if (system.data.debug || this.data.debug) {
-      this.el.object3D.add(createSphereGizmo(this.data.radius));
-    }
     if (this.data.useMaterial) {
       const mesh = findInvaderMesh(this.el);
       if (mesh) {
@@ -124,6 +135,16 @@ AFRAME.registerComponent("personal-space-invader", {
 
   update() {
     this.radiusSquared = this.data.radius * this.data.radius;
+    this.updateDebug();
+  },
+
+  updateDebug() {
+    const system = this.el.sceneEl.systems["personal-space-bubble"];
+    if (system.data.debug || this.data.debug) {
+      !this.el.object3DMap[DEBUG_OBJ] && this.el.setObject3D(DEBUG_OBJ, createSphereGizmo(this.data.radius));
+    } else if (this.el.object3DMap[DEBUG_OBJ]) {
+      this.el.removeObject3D(DEBUG_OBJ);
+    }
   },
 
   remove() {
@@ -148,13 +169,19 @@ AFRAME.registerComponent("personal-space-bubble", {
   },
   init() {
     this.system.registerBubble(this);
-    if (this.system.data.debug || this.data.debug) {
-      this.el.object3D.add(createSphereGizmo(this.data.radius));
-    }
   },
 
   update() {
     this.radiusSquared = this.data.radius * this.data.radius;
+    this.updateDebug();
+  },
+
+  updateDebug() {
+    if (this.system.data.debug || this.data.debug) {
+      !this.el.object3DMap[DEBUG_OBJ] && this.el.setObject3D(DEBUG_OBJ, createSphereGizmo(this.data.radius));
+    } else if (this.el.object3DMap[DEBUG_OBJ]) {
+      this.el.removeObject3D(DEBUG_OBJ);
+    }
   },
 
   remove() {

--- a/src/systems/personal-space-bubble.js
+++ b/src/systems/personal-space-bubble.js
@@ -153,7 +153,7 @@ AFRAME.registerComponent("personal-space-invader", {
 
   setInvading(invading) {
     if (this.targetMaterial) {
-      this.targetMaterial.opacity = invading ? 0.3 : 1;
+      this.targetMaterial.opacity = invading ? this.data.invadingOpacity : 1;
       this.targetMaterial.transparent = invading;
     } else {
       this.el.object3D.visible = !invading;

--- a/src/systems/personal-space-bubble.js
+++ b/src/systems/personal-space-bubble.js
@@ -11,12 +11,12 @@ AFRAME.registerSystem("personal-space-bubble", {
     this.bubbles = [];
   },
 
-  registerBubble(el) {
-    this.bubbles.push(el);
+  registerBubble(bubble) {
+    this.bubbles.push(bubble);
   },
 
-  unregisterBubble(el) {
-    const index = this.bubbles.indexOf(el);
+  unregisterBubble(bubble) {
+    const index = this.bubbles.indexOf(bubble);
 
     if (index !== -1) {
       this.bubbles.splice(index, 1);
@@ -44,7 +44,7 @@ AFRAME.registerSystem("personal-space-bubble", {
   tick() {
     // Update matrix positions once for each space bubble and space invader
     for (let i = 0; i < this.bubbles.length; i++) {
-      this.bubbles[i].object3D.updateMatrixWorld(true);
+      this.bubbles[i].el.object3D.updateMatrixWorld(true);
     }
 
     for (let i = 0; i < this.invaders.length; i++) {
@@ -56,9 +56,7 @@ AFRAME.registerSystem("personal-space-bubble", {
     for (let i = 0; i < this.bubbles.length; i++) {
       const bubble = this.bubbles[i];
 
-      bubblePos.setFromMatrixPosition(bubble.object3D.matrixWorld);
-
-      const bubbleRadius = bubble.components["personal-space-bubble"].data.radius;
+      bubblePos.setFromMatrixPosition(bubble.el.object3D.matrixWorld);
 
       // Hide the invader if inside the bubble
       for (let j = 0; j < this.invaders.length; j++) {
@@ -67,8 +65,8 @@ AFRAME.registerSystem("personal-space-bubble", {
         invaderPos.setFromMatrixPosition(invader.el.object3D.matrixWorld);
 
         const distanceSquared = bubblePos.distanceToSquared(invaderPos);
-        const radius = bubbleRadius + invader.data.radius;
-        if (distanceSquared < radius * radius) {
+        const radiusSum = bubble.data.radius + invader.data.radius;
+        if (distanceSquared < radiusSum * radiusSum) {
           invader.setInvading(true);
         }
       }
@@ -149,7 +147,7 @@ AFRAME.registerComponent("personal-space-bubble", {
     debug: { default: false }
   },
   init() {
-    this.system.registerBubble(this.el);
+    this.system.registerBubble(this);
     if (this.system.data.debug || this.data.debug) {
       this.el.object3D.add(createSphereGizmo(this.data.radius));
     }
@@ -160,6 +158,6 @@ AFRAME.registerComponent("personal-space-bubble", {
   },
 
   remove() {
-    this.system.unregisterBubble(this.el);
+    this.system.unregisterBubble(this);
   }
 });


### PR DESCRIPTION
Space bubbles are currently broken. This PR fixes them but also attempts to make them better by:
- allowing individual `personal-space-invaders` to specify their own radius, giving better control over when personal space should be triggered
- using transparency for certain personal space invasions (instead of fully hiding the objects)

This also cleans up some of the visibility code that was scattered throughout.

Todo:
[] Need to deal with the fact that both `ik-controller` and `personal-space-bubble` want to control hand visiblity.