### PR TITLE
Enter in VR properly on GearVR

### DIFF
--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -250,7 +250,7 @@ class UIRoot extends Component {
   };
 
   enterGearVR = async () => {
-    if (this.state.availableVREntryTypes.daydream !== VR_DEVICE_AVAILABILITY.yes) {
+    if (this.state.availableVREntryTypes.gearvr !== VR_DEVICE_AVAILABILITY.yes) {
       await this.performDirectEntryFlow(true);
     } else {
       this.exit();

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -131,6 +131,10 @@ class UIRoot extends Component {
       this.enterDaydream();
     } else if (this.props.forcedVREntryType === "gearvr") {
       this.enterGearVR();
+    } else if (this.props.forcedVREntryType === "vr") {
+      this.enterVR();
+    } else if (this.props.forcedVREntryType === "2d") {
+      this.enter2D();
     }
   };
 
@@ -246,18 +250,22 @@ class UIRoot extends Component {
   };
 
   enterGearVR = async () => {
-    this.exit();
+    if (true || this.state.availableVREntryTypes.daydream !== VR_DEVICE_AVAILABILITY.yes) {
+      await this.performDirectEntryFlow(true);
+    } else {
+      this.exit();
 
-    // Launch via Oculus Browser
-    const location = window.location;
-    const qs = queryString.parse(location.search);
-    qs.vr_entry_type = "gearvr"; // Auto-choose 'gearvr' after landing in Oculus Browser
+      // Launch via Oculus Browser
+      const location = window.location;
+      const qs = queryString.parse(location.search);
+      qs.vr_entry_type = "gearvr"; // Auto-choose 'gearvr' after landing in Oculus Browser
 
-    const ovrwebUrl =
-      `ovrweb://${location.protocol || "http:"}//${location.host}` +
-      `${location.pathname || ""}?${queryString.stringify(qs)}#${location.hash || ""}`;
+      const ovrwebUrl =
+        `ovrweb://${location.protocol || "http:"}//${location.host}` +
+        `${location.pathname || ""}?${queryString.stringify(qs)}#${location.hash || ""}`;
 
-    window.location = ovrwebUrl;
+      window.location = ovrwebUrl;
+    }
   };
 
   enterDaydream = async () => {

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -250,7 +250,7 @@ class UIRoot extends Component {
   };
 
   enterGearVR = async () => {
-    if (this.state.availableVREntryTypes.gearvr !== VR_DEVICE_AVAILABILITY.yes) {
+    if (this.state.availableVREntryTypes.gearvr === VR_DEVICE_AVAILABILITY.yes) {
       await this.performDirectEntryFlow(true);
     } else {
       this.exit();

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -250,7 +250,7 @@ class UIRoot extends Component {
   };
 
   enterGearVR = async () => {
-    if (true || this.state.availableVREntryTypes.daydream !== VR_DEVICE_AVAILABILITY.yes) {
+    if (this.state.availableVREntryTypes.daydream !== VR_DEVICE_AVAILABILITY.yes) {
       await this.performDirectEntryFlow(true);
     } else {
       this.exit();

--- a/src/utils/vr-caps-detect.js
+++ b/src/utils/vr-caps-detect.js
@@ -41,6 +41,7 @@ const GENERIC_ENTRY_TYPE_DEVICE_BLACKLIST = [/cardboard/i];
 export async function getAvailableVREntryTypes() {
   const isWebVRCapableBrowser = !!navigator.getVRDisplays;
   const isSamsungBrowser = browser.name === "chrome" && navigator.userAgent.match(/SamsungBrowser/);
+  const isOculusBrowser = navigator.userAgent.match(/Oculus/);
   const isDaydreamCapableBrowser = !!(isWebVRCapableBrowser && browser.name === "chrome" && !isSamsungBrowser);
 
   let generic = VR_DEVICE_AVAILABILITY.no;
@@ -49,7 +50,11 @@ export async function getAvailableVREntryTypes() {
   // We only consider GearVR support as "maybe" and never "yes". The only browser
   // that will detect GearVR outside of VR is Samsung Internet, and we'd prefer to launch into Oculus
   // Browser for now since Samsung Internet requires an additional WebVR installation + flag, so return "maybe".
-  const gearvr = isMaybeGearVRCompatibleDevice() ? VR_DEVICE_AVAILABILITY.maybe : VR_DEVICE_AVAILABILITY.no;
+  //
+  // If we are in Oculus Browser (ie, we are literally wearing a GearVR) then return 'yes'.
+  const gearvr = isMaybeGearVRCompatibleDevice()
+    ? isOculusBrowser ? VR_DEVICE_AVAILABILITY.yes : VR_DEVICE_AVAILABILITY.maybe
+    : VR_DEVICE_AVAILABILITY.no;
 
   // For daydream detection, we first check if they are on an Android compatible device, and assume they
   // may support daydream *unless* this browser has WebVR capabilities, in which case we can do better.


### PR DESCRIPTION
This PR properly handles the `vr_entry_type=gearvr` case once we've entered Oculus Browser. (Previously it would just continually try to go to the `ovrweb` URL)