### PR TITLE
Bug/macos blur perf

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
   rules: {
     "prettier/prettier": "error",
     "prefer-const": "error",
+    "no-use-before-define": "error",
     "no-var": "error",
     "no-throw-literal": "error",
     // Light console usage is useful but remove debug logs before merging to master.

--- a/src/components/super-cursor.js
+++ b/src/components/super-cursor.js
@@ -106,7 +106,7 @@ AFRAME.registerComponent("super-cursor", {
   _handleMouseDown: function() {
     if (this.isInteractable) {
       const lookControls = this.data.camera.components["look-controls"];
-      lookControls.pause();
+      if (lookControls) lookControls.pause();
     }
     this.data.cursor.emit("action_grab", {});
   },
@@ -117,7 +117,7 @@ AFRAME.registerComponent("super-cursor", {
 
   _handleMouseUp: function() {
     const lookControls = this.data.camera.components["look-controls"];
-    lookControls.play();
+    if (lookControls) lookControls.play();
     this.data.cursor.emit("action_release", {});
   },
 

--- a/src/hub.html
+++ b/src/hub.html
@@ -15,6 +15,7 @@
 </head>
 
 <body data-html-prefix="<%= HTML_PREFIX %>">
+    <script>(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();document.body.appendChild(stats.dom);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='//rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()</script>
     <audio id="test-tone" src="./assets/sfx/tone.ogg"></audio>
 
     <a-scene
@@ -187,7 +188,6 @@
                 camera
                 position="0 1.6 0"
                 personal-space-bubble="radius: 0.4"
-                look-controls
             ></a-entity>
 
             <a-entity

--- a/src/hub.html
+++ b/src/hub.html
@@ -15,7 +15,6 @@
 </head>
 
 <body data-html-prefix="<%= HTML_PREFIX %>">
-    <script>(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();document.body.appendChild(stats.dom);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='//rawgit.com/mrdoob/stats.js/master/build/stats.min.js';document.head.appendChild(script);})()</script>
     <audio id="test-tone" src="./assets/sfx/tone.ogg"></audio>
 
     <a-scene

--- a/src/hub.js
+++ b/src/hub.js
@@ -1,5 +1,6 @@
 import "./assets/stylesheets/hub.scss";
 import queryString from "query-string";
+import { debounce } from "lodash";
 
 import { patchWebGLRenderingContext } from "./utils/webgl";
 patchWebGLRenderingContext();
@@ -126,6 +127,7 @@ async function enterScene(mediaStream, enterInVR, janusRoomId) {
   const scene = document.querySelector("a-scene");
   const playerRig = document.querySelector("#player-rig");
   document.querySelector("a-scene canvas").classList.remove("blurred");
+  scene.render();
 
   if (enterInVR) {
     scene.enterVR();
@@ -179,11 +181,7 @@ async function enterScene(mediaStream, enterInVR, janusRoomId) {
     screenEntity.setAttribute("visible", sharingScreen);
   });
 
-  if (qsTruthy("offline")) {
-    onConnect();
-  } else {
-    document.body.addEventListener("connected", onConnect);
-
+  if (!qsTruthy("offline")) {
     scene.components["networked-scene"].connect();
 
     if (mediaStream) {
@@ -206,8 +204,6 @@ async function enterScene(mediaStream, enterInVR, janusRoomId) {
     }
   }
 }
-
-function onConnect() {}
 
 function mountUI(scene) {
   const disableAutoExitOnConcurrentLoad = qsTruthy("allow_multi");
@@ -255,7 +251,10 @@ const onReady = async () => {
   const environmentRoot = document.querySelector("#environment-root");
 
   const initialEnvironmentEl = document.createElement("a-entity");
-  initialEnvironmentEl.addEventListener("bundleloaded", () => uiRoot.setState({ initialEnvironmentLoaded: true }));
+  initialEnvironmentEl.addEventListener("bundleloaded", () => {
+    uiRoot.setState({ initialEnvironmentLoaded: true });
+    setTimeout(() => scene.renderer.animate(null), 100);
+  });
   environmentRoot.appendChild(initialEnvironmentEl);
 
   if (qs.room) {

--- a/src/hub.js
+++ b/src/hub.js
@@ -252,7 +252,8 @@ const onReady = async () => {
   const initialEnvironmentEl = document.createElement("a-entity");
   initialEnvironmentEl.addEventListener("bundleloaded", () => {
     uiRoot.setState({ initialEnvironmentLoaded: true });
-    setTimeout(() => scene.renderer.animate(null), 100);
+    // Wait a tick so that the environments actually render.
+    setTimeout(() => scene.renderer.animate(null));
   });
   environmentRoot.appendChild(initialEnvironmentEl);
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -134,7 +134,7 @@ async function enterScene(mediaStream, enterInVR, janusRoomId) {
 
   AFRAME.registerInputActions(inGameActions, "default");
 
-  document.querySelector("#player-camera").setAttribute("look-controls");
+  document.querySelector("#player-camera").setAttribute("look-controls", "");
 
   scene.setAttribute("networked-scene", {
     room: janusRoomId,

--- a/src/hub.js
+++ b/src/hub.js
@@ -1,6 +1,5 @@
 import "./assets/stylesheets/hub.scss";
 import queryString from "query-string";
-import { debounce } from "lodash";
 
 import { patchWebGLRenderingContext } from "./utils/webgl";
 patchWebGLRenderingContext();

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -60,7 +60,7 @@ class UIRoot extends Component {
     enableScreenSharing: PropTypes.bool,
     store: PropTypes.object,
     scene: PropTypes.object,
-    htmlPrefix: PropTypes.object
+    htmlPrefix: PropTypes.string
   };
 
   state = {

--- a/src/vendor/GLTFLoader.js
+++ b/src/vendor/GLTFLoader.js
@@ -29,6 +29,8 @@ THREE.GLTFLoader = ( function () {
 
 			var scope = this;
 
+			scope.url = url;
+
 			var path = this.path !== undefined ? this.path : THREE.LoaderUtils.extractUrlBase( url );
 
 			var loader = new THREE.FileLoader( scope.manager );
@@ -39,7 +41,7 @@ THREE.GLTFLoader = ( function () {
 
 				try {
 
-					scope.parse( url, data, path, onLoad, onError );
+					scope.parse( data, path, onLoad, onError );
 
 				} catch ( e ) {
 
@@ -80,8 +82,9 @@ THREE.GLTFLoader = ( function () {
 
 		},
 
-		parse: function ( url, data, path, onLoad, onError ) {
+		parse: function ( data, path, onLoad, onError ) {
 
+			var scope = this;
 			var content;
 			var extensions = {};
 
@@ -159,7 +162,7 @@ THREE.GLTFLoader = ( function () {
 
 			}
 
-			console.time( `GLTFLoader - ${url}` );
+			console.time( `GLTFLoader - ${scope.url}` );
 
 			var parser = new GLTFParser( json, extensions, {
 
@@ -171,7 +174,7 @@ THREE.GLTFLoader = ( function () {
 
 			parser.parse( function ( scene, scenes, cameras, animations, asset ) {
 
-				console.timeEnd( `GLTFLoader - ${url}` );
+				console.timeEnd( `GLTFLoader - ${scope.url}` );
 
 				var glTF = {
 					scene: scene,

--- a/src/vendor/GLTFLoader.js
+++ b/src/vendor/GLTFLoader.js
@@ -39,7 +39,7 @@ THREE.GLTFLoader = ( function () {
 
 				try {
 
-					scope.parse( data, path, onLoad, onError );
+					scope.parse( url, data, path, onLoad, onError );
 
 				} catch ( e ) {
 
@@ -80,7 +80,7 @@ THREE.GLTFLoader = ( function () {
 
 		},
 
-		parse: function ( data, path, onLoad, onError ) {
+		parse: function ( url, data, path, onLoad, onError ) {
 
 			var content;
 			var extensions = {};
@@ -159,7 +159,7 @@ THREE.GLTFLoader = ( function () {
 
 			}
 
-			console.time( 'GLTFLoader' );
+			console.time( `GLTFLoader - ${url}` );
 
 			var parser = new GLTFParser( json, extensions, {
 
@@ -171,7 +171,7 @@ THREE.GLTFLoader = ( function () {
 
 			parser.parse( function ( scene, scenes, cameras, animations, asset ) {
 
-				console.timeEnd( 'GLTFLoader' );
+				console.timeEnd( `GLTFLoader - ${url}` );
 
 				var glTF = {
 					scene: scene,


### PR DESCRIPTION
Figured out a way to keep the blur but reduce perf. Basically I let a-frame render until its loaded the environment, then I pause the render loop. This seems to fix the perf issue with the blur effect on macos Firefox. (For #116)

Also fixed a bunch of small issues:
- Fix regression with look-controls so that it's not active when the react UI is up.
- Removed unused `onConnect` method
- Fix htmlPrefix error message
- Fix GLTFLoader timer warnings