### PR TITLE
Update input schemes

### DIFF
--- a/src/behaviours/joystick-dpad4.js
+++ b/src/behaviours/joystick-dpad4.js
@@ -1,7 +1,7 @@
 import { angleTo4Direction } from "../utils/dpad";
 
 // @TODO specify 4 or 8 direction
-function oculus_touch_joystick_dpad4(el, outputPrefix) {
+function joystick_dpad4(el, outputPrefix) {
   this.angleToDirection = angleTo4Direction;
   this.outputPrefix = outputPrefix;
   this.centerRadius = 0.6;
@@ -11,7 +11,7 @@ function oculus_touch_joystick_dpad4(el, outputPrefix) {
   el.addEventListener("axismove", this.emitDPad4);
 }
 
-oculus_touch_joystick_dpad4.prototype = {
+joystick_dpad4.prototype = {
   emitDPad4: function(event) {
     const x = event.detail.axis[0];
     const y = event.detail.axis[1];
@@ -25,4 +25,4 @@ oculus_touch_joystick_dpad4.prototype = {
   }
 };
 
-export { oculus_touch_joystick_dpad4 };
+export default joystick_dpad4;

--- a/src/behaviours/trackpad-dpad4.js
+++ b/src/behaviours/trackpad-dpad4.js
@@ -1,6 +1,6 @@
 import { angleTo4Direction } from "../utils/dpad";
 
-function vive_trackpad_dpad4(el, outputPrefix) {
+function trackpad_dpad4(el, outputPrefix) {
   this.outputPrefix = outputPrefix;
   this.lastDirection = "";
   this.previous = "";
@@ -15,7 +15,7 @@ function vive_trackpad_dpad4(el, outputPrefix) {
   el.addEventListener("trackpadup", this.unpress);
 }
 
-vive_trackpad_dpad4.prototype = {
+trackpad_dpad4.prototype = {
   press: function() {
     this.pressed = true;
   },
@@ -51,4 +51,4 @@ vive_trackpad_dpad4.prototype = {
   }
 };
 
-export { vive_trackpad_dpad4 };
+export default trackpad_dpad4;

--- a/src/hub.js
+++ b/src/hub.js
@@ -13,8 +13,8 @@ import "aframe-input-mapping-component";
 import "aframe-billboard-component";
 import "webrtc-adapter";
 
-import { vive_trackpad_dpad4 } from "./behaviours/vive-trackpad-dpad4";
-import { oculus_touch_joystick_dpad4 } from "./behaviours/oculus-touch-joystick-dpad4";
+import trackpad_dpad4 from "./behaviours/trackpad-dpad4";
+import { joystick_dpad4 } from "./behaviours/joystick-dpad4";
 import { PressedMove } from "./activators/pressedmove";
 import { ReverseY } from "./activators/reversey";
 import "./activators/shortpress";
@@ -94,8 +94,8 @@ function qsTruthy(param) {
 
 registerTelemetry();
 
-AFRAME.registerInputBehaviour("vive_trackpad_dpad4", vive_trackpad_dpad4);
-AFRAME.registerInputBehaviour("oculus_touch_joystick_dpad4", oculus_touch_joystick_dpad4);
+AFRAME.registerInputBehaviour("trackpad_dpad4", trackpad_dpad4);
+AFRAME.registerInputBehaviour("joystick_dpad4", joystick_dpad4);
 AFRAME.registerInputActivator("pressedmove", PressedMove);
 AFRAME.registerInputActivator("reverseY", ReverseY);
 AFRAME.registerInputMappings(inputConfig, true);

--- a/src/input-mappings.js
+++ b/src/input-mappings.js
@@ -21,29 +21,35 @@ const config = {
   behaviours: {
     default: {
       "oculus-touch-controls": {
-        joystick: "oculus_touch_joystick_dpad4"
+        joystick: "joystick_dpad4"
       },
       "vive-controls": {
-        trackpad: "vive_trackpad_dpad4"
+        trackpad: "trackpad_dpad4"
+      },
+      "daydream-controls": {
+        trackpad: "trackpad_dpad4"
+      },
+      "gearvr-controls": {
+        trackpad: "trackpad_dpad4"
       }
     }
   },
   mappings: {
     default: {
       "vive-controls": {
-        menudown: ["action_mute", "thumb_down"],
-        menuup: "thumb_up",
         "trackpad.pressedmove": { left: "move" },
         trackpad_dpad4_pressed_west_down: { right: "snap_rotate_left" },
         trackpad_dpad4_pressed_east_down: { right: "snap_rotate_right" },
         trackpad_dpad4_pressed_center_down: { right: "action_teleport_down" },
         trackpadup: { right: "action_teleport_up" },
-        gripdown: ["action_grab", "middle_ring_pinky_down", "index_down"],
-        gripup: ["action_release", "middle_ring_pinky_up", "index_up"],
+        menudown: "thumb_down",
+        menuup: "thumb_up",
+        gripdown: ["middle_ring_pinky_down", "index_down"],
+        gripup: ["middle_ring_pinky_up", "index_up"],
         trackpadtouchstart: "thumb_down",
         trackpadtouchend: "thumb_up",
-        triggerdown: "index_down",
-        triggerup: "index_up"
+        triggerdown: ["action_grab", "index_down"],
+        triggerup: ["action_release", "index_up"]
       },
       "oculus-touch-controls": {
         joystick_dpad4_west: {
@@ -52,7 +58,6 @@ const config = {
         joystick_dpad4_east: {
           right: "snap_rotate_right"
         },
-        xbuttondown: "action_mute",
         gripdown: ["action_grab", "middle_ring_pinky_down"],
         gripup: ["action_release", "middle_ring_pinky_up"],
         abuttontouchstart: "thumb_down",
@@ -67,20 +72,22 @@ const config = {
         surfacetouchend: "thumb_up",
         thumbsticktouchstart: "thumb_down",
         thumbsticktouchend: "thumb_up",
-        triggerdown: ["action_teleport_down", "index_down"],
-        triggerup: ["action_teleport_up", "index_up"],
+        triggerdown: "index_down",
+        triggerup: "index_up",
         "axismove.reverseY": { left: "move" },
-        right_dpad_east: "snap_rotate_right",
-        right_dpad_west: "snap_rotate_left",
         abuttondown: "action_teleport_down",
         abuttonup: "action_teleport_up"
       },
       "daydream-controls": {
-        trackpaddown: "action_teleport_down",
+        trackpad_dpad4_pressed_west_down: "snap_rotate_left",
+        trackpad_dpad4_pressed_east_down: "snap_rotate_right",
+        trackpad_dpad4_pressed_center_down: "action_teleport_down",
         trackpadup: "action_teleport_up"
       },
       "gearvr-controls": {
-        trackpaddown: "action_teleport_down",
+        trackpad_dpad4_pressed_west_down: "snap_rotate_left",
+        trackpad_dpad4_pressed_east_down: "snap_rotate_right",
+        trackpad_dpad4_pressed_center_down: "action_teleport_down",
         trackpadup: "action_teleport_up"
       },
       keyboard: {
@@ -100,14 +107,14 @@ const config = {
         s_up: "s_up",
         d_down: "d_down",
         d_up: "d_up",
-        W_down: "w_down",
-        W_up: "w_up",
-        A_down: "a_down",
-        A_up: "a_up",
-        S_down: "s_down",
-        S_up: "s_up",
-        D_down: "d_down",
-        D_up: "d_up"
+        arrowup_down: "w_down",
+        arrowup_up: "w_up",
+        arrowleft_down: "a_down",
+        arrowleft_up: "a_up",
+        arrowdown_down: "s_down",
+        arrowdown_up: "s_up",
+        arrowright_down: "d_down",
+        arrowright_up: "d_up"
       }
     },
     hud: {
@@ -116,8 +123,8 @@ const config = {
         triggerup: { right: "action_ui_select_up" }
       },
       "oculus-touch-controls": {
-        triggerdown: { right: "action_ui_select_down" },
-        triggerup: { right: "action_ui_select_up" },
+        abuttondown: "action_ui_select_down",
+        abuttonup: "action_ui_select_up",
         gripdown: "middle_ring_pinky_down",
         gripup: "middle_ring_pinky_up",
         abuttontouchstart: "thumb_down",


### PR DESCRIPTION
This updates the input schemes (#167) on all platforms to be more consistant and remove duplicated funcitonality on buttons. 

Big changes are upport for ratchet turning to gearvr and daydream, using trigger for grab on vive, remove of duplicate teleport butotns on oculus, and removal of mute buttons on oculus and vive (these are now handled via the HUD). Daydream and gearvr still have no way to pick up objects, but this will come with the cursor changes. 

Also fixes #163 by adding support for arrow keys.