### PR TITLE
Set up dev server

### DIFF
--- a/scripts/default.env
+++ b/scripts/default.env
@@ -3,3 +3,4 @@
 ORIGIN_TRIAL_TOKEN="ArEZ0vY0uMo3pj+oY8Up4u4Hy8QolJwKxG4/2WRhSPnTZRrviiGhzP6/y72nBdsIhdEyoundxqg//KLbs2vGnQoAAABkeyJvcmlnaW4iOiJodHRwczovL3JldGljdWx1bS5pbzo0NDMiLCJmZWF0dXJlIjoiV2ViVlIxLjFNNjIiLCJleHBpcnkiOjE1MjYzNDg2MjEsImlzU3ViZG9tYWluIjp0cnVlfQ=="
 ORIGIN_TRIAL_EXPIRES="2018-05-15"
 JANUS_SERVER="wss://prod-janus.reticulum.io"
+DEV_RETICULUM_SERVER="dev.reticulum.io"

--- a/src/hub.js
+++ b/src/hub.js
@@ -304,7 +304,8 @@ const onReady = async () => {
   const socketProtocol = document.location.protocol === "https:" ? "wss:" : "ws:";
   const socketPort = qs.phx_port || (process.env.NODE_ENV === "production" ? document.location.port : 443);
   const socketHost =
-    qs.phx_host || (process.env.NODE_ENV === "production" ? document.location.hostname : "dev.reticulum.io");
+    qs.phx_host ||
+    (process.env.NODE_ENV === "production" ? document.location.hostname : process.env.DEV_RETICULUM_SERVER);
   const socketUrl = `${socketProtocol}//${socketHost}${socketPort ? `:${socketPort}` : ""}/socket`;
   console.log(`Phoenix Channel URL: ${socketUrl}`);
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -302,8 +302,9 @@ const onReady = async () => {
   console.log(`Hub ID: ${hubId}`);
 
   const socketProtocol = document.location.protocol === "https:" ? "wss:" : "ws:";
-  const socketPort = qs.phx_port || document.location.port;
-  const socketHost = qs.phx_host || document.location.hostname;
+  const socketPort = qs.phx_port || (process.env.NODE_ENV === "production" ? document.location.port : 443);
+  const socketHost =
+    qs.phx_host || (process.env.NODE_ENV === "production" ? document.location.hostname : "dev.reticulum.io");
   const socketUrl = `${socketProtocol}//${socketHost}${socketPort ? `:${socketPort}` : ""}/socket`;
   console.log(`Phoenix Channel URL: ${socketUrl}`);
 

--- a/src/react-components/hub-create-panel.js
+++ b/src/react-components/hub-create-panel.js
@@ -44,7 +44,7 @@ class HubCreatePanel extends Component {
       createUrl = `https://dev.reticulum.io${createUrl}`;
     }
 
-    const res = await fetch("https://dev.reticulum.io/api/v1/hubs", {
+    const res = await fetch(createUrl, {
       body: JSON.stringify(payload),
       headers: { "content-type": "application/json" },
       method: "POST"

--- a/src/react-components/hub-create-panel.js
+++ b/src/react-components/hub-create-panel.js
@@ -38,14 +38,25 @@ class HubCreatePanel extends Component {
       hub: { name: this.state.name, default_environment_gltf_bundle_url: environment.bundle_url }
     };
 
-    const res = await fetch("/api/v1/hubs", {
+    let createUrl = "/api/v1/hubs";
+
+    if (process.env.NODE_ENV === "development") {
+      createUrl = `https://dev.reticulum.io${createUrl}`;
+    }
+
+    const res = await fetch("https://dev.reticulum.io/api/v1/hubs", {
       body: JSON.stringify(payload),
       headers: { "content-type": "application/json" },
       method: "POST"
     });
 
     const hub = await res.json();
-    document.location = hub.url;
+
+    if (process.env.NODE_ENV === "production") {
+      document.location = hub.url;
+    } else {
+      document.location = `/hub.html?hub_id=${hub.hub_id}`;
+    }
   };
 
   isHubNameValid = () => {

--- a/src/react-components/hub-create-panel.js
+++ b/src/react-components/hub-create-panel.js
@@ -41,7 +41,7 @@ class HubCreatePanel extends Component {
     let createUrl = "/api/v1/hubs";
 
     if (process.env.NODE_ENV === "development") {
-      createUrl = `https://dev.reticulum.io${createUrl}`;
+      createUrl = `https://${process.env.DEV_RETICULUM_SERVER}${createUrl}`;
     }
 
     const res = await fetch(createUrl, {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -216,7 +216,8 @@ const config = {
     new webpack.DefinePlugin({
       "process.env": JSON.stringify({
         NODE_ENV: process.env.NODE_ENV,
-        JANUS_SERVER: process.env.JANUS_SERVER
+        JANUS_SERVER: process.env.JANUS_SERVER,
+        DEV_RETICULUM_SERVER: process.env.DEV_RETICULUM_SERVER
       })
     })
   ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,7 +87,7 @@ const config = {
   mode: "development",
   devtool: process.env.NODE_ENV === "production" ? "source-map" : "inline-source-map",
   devServer: {
-    open: true,
+    open: false,
     https: createHTTPSConfig(),
     host: "0.0.0.0",
     useLocalIp: true,


### PR DESCRIPTION
This PR rigs things up so `yarn start` will use `dev.reticulum.io` for its API and Phoenix Channels domain.

Note: for it to work you will need to hit `https://localhost:8080`, if you need to test on another origin you will need to set up your own reticulum and pass `phx_host` and `phx_port` to `hub.html`.

This also turns off the annoying "open up a new browser window when I run start" thing